### PR TITLE
Remove obsolete GSIM objects

### DIFF
--- a/src/main/java/no/ssb/exploration/SimpleToExploration.java
+++ b/src/main/java/no/ssb/exploration/SimpleToExploration.java
@@ -129,9 +129,6 @@ public class SimpleToExploration {
                             .shortName(instance.getName())
                             .population(instance.getPopulation(), "Population_DUMMY")
                             .dataStructureComponentType(instance.getDataStructureComponentType(), "MEASURE")
-                            .dataStructureComponentRole(instance.getDataStructureComponentRole(), "ENTITY")
-                            .identifierComponentIsComposite(instance.getIdentifierComponentIsComposite())
-                            .identifierComponentIsUnique(instance.getIdentifierComponentIsUnique())
                             .sentinelValueDomain(instance.getSentinelValueDomain(), "DescribedValueDomain_DUMMY")
                             .representedVariable(instance.getRepresentedVariable(), "RepresentedVariable_DUMMY")
                             .build();

--- a/src/main/java/no/ssb/exploration/model/GsimBuilder.java
+++ b/src/main/java/no/ssb/exploration/model/GsimBuilder.java
@@ -300,25 +300,9 @@ public class GsimBuilder {
             return this;
         }
 
-        public InstanceVariableBuilder identifierComponentIsComposite(boolean identifierComponentIsComposite) {
-            instanceVariable.setIdentifierComponentIsComposite(identifierComponentIsComposite);
-            return this;
-        }
-
         public InstanceVariableBuilder sentinelValueDomain(TypeInfo sentinelValueDomain, String defaultValue) {
             String value = sentinelValueDomain != null ? sentinelValueDomain.getId() : defaultValue;
             instanceVariable.setSentinelValueDomain("/DescribedValueDomain/" + value);
-            return this;
-        }
-
-        public InstanceVariableBuilder identifierComponentIsUnique(boolean identifierComponentIsUnique) {
-            instanceVariable.setIdentifierComponentIsUnique(identifierComponentIsUnique);
-            return this;
-        }
-
-        public InstanceVariableBuilder dataStructureComponentRole(EnumInfo dataStructureComponentRole, String defaultValue) {
-            String value = dataStructureComponentRole != null ? dataStructureComponentRole.getValue() : defaultValue;
-            instanceVariable.setDataStructureComponentRole(value);
             return this;
         }
 

--- a/src/main/java/no/ssb/exploration/model/InstanceVariable.java
+++ b/src/main/java/no/ssb/exploration/model/InstanceVariable.java
@@ -1,23 +1,16 @@
 package no.ssb.exploration.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class InstanceVariable extends IdentifiableArtefact {
 
-    public static final String INSTANCE_VARIABLE_NAME = "InstanceVariable";
-
     @JsonProperty
     private String shortName;
     @JsonProperty
-    private String dataStructureComponentRole;
-    @JsonProperty
     private String dataStructureComponentType;
-    @JsonProperty
-    private boolean identifierComponentIsComposite;
-    @JsonProperty
-    private boolean identifierComponentIsUnique;
     @JsonProperty
     private String representedVariable;
     @JsonProperty
@@ -31,13 +24,6 @@ public class InstanceVariable extends IdentifiableArtefact {
         this.shortName = shortName;
     }
 
-    public String getDataStructureComponentRole() {
-        return dataStructureComponentRole;
-    }
-
-    public void setDataStructureComponentRole(String dataStructureComponentRole) {
-        this.dataStructureComponentRole = dataStructureComponentRole;
-    }
 
     public String getDataStructureComponentType() {
         return dataStructureComponentType;
@@ -45,22 +31,6 @@ public class InstanceVariable extends IdentifiableArtefact {
 
     public void setDataStructureComponentType(String dataStructureComponentType) {
         this.dataStructureComponentType = dataStructureComponentType;
-    }
-
-    public boolean getIdentifierComponentIsComposite() {
-        return identifierComponentIsComposite;
-    }
-
-    public void setIdentifierComponentIsComposite(boolean identifierComponentIsComposite) {
-        this.identifierComponentIsComposite = identifierComponentIsComposite;
-    }
-
-    public boolean getIdentifierComponentIsUnique() {
-        return identifierComponentIsUnique;
-    }
-
-    public void setIdentifierComponentIsUnique(boolean identifierComponentIsUnique) {
-        this.identifierComponentIsUnique = identifierComponentIsUnique;
     }
 
     public String getRepresentedVariable() {

--- a/src/test/resources/testdata/gsim_1_level/InstanceVariable_path.to.dataset$gjeld.json
+++ b/src/test/resources/testdata/gsim_1_level/InstanceVariable_path.to.dataset$gjeld.json
@@ -1,10 +1,7 @@
 {
   "id" : "path.to.dataset$gjeld",
   "shortName" : "gjeld",
-  "dataStructureComponentRole" : "ENTITY",
   "dataStructureComponentType" : "MEASURE",
-  "identifierComponentIsComposite" : false,
-  "identifierComponentIsUnique" : false,
   "representedVariable" : "/RepresentedVariable/RepresentedVariable_DUMMY",
   "sentinelValueDomain" : "/DescribedValueDomain/DescribedValueDomain_DUMMY",
   "name" : [ {

--- a/src/test/resources/testdata/gsim_1_level/InstanceVariable_path.to.dataset$innskudd.json
+++ b/src/test/resources/testdata/gsim_1_level/InstanceVariable_path.to.dataset$innskudd.json
@@ -1,10 +1,7 @@
 {
   "id" : "path.to.dataset$innskudd",
   "shortName" : "innskudd",
-  "dataStructureComponentRole" : "ENTITY",
   "dataStructureComponentType" : "MEASURE",
-  "identifierComponentIsComposite" : false,
-  "identifierComponentIsUnique" : false,
   "representedVariable" : "/RepresentedVariable/RepresentedVariable_DUMMY",
   "sentinelValueDomain" : "/DescribedValueDomain/DescribedValueDomain_DUMMY",
   "name" : [ {

--- a/src/test/resources/testdata/gsim_1_level/InstanceVariable_path.to.dataset$kontonummer.json
+++ b/src/test/resources/testdata/gsim_1_level/InstanceVariable_path.to.dataset$kontonummer.json
@@ -1,10 +1,7 @@
 {
   "id" : "path.to.dataset$kontonummer",
   "shortName" : "kontonummer",
-  "dataStructureComponentRole" : "ENTITY",
   "dataStructureComponentType" : "MEASURE",
-  "identifierComponentIsComposite" : false,
-  "identifierComponentIsUnique" : false,
   "representedVariable" : "/RepresentedVariable/RepresentedVariable_DUMMY",
   "sentinelValueDomain" : "/DescribedValueDomain/DescribedValueDomain_DUMMY",
   "name" : [ {

--- a/src/test/resources/testdata/gsim_2_levels/InstanceVariable_path.to.dataset$group.json
+++ b/src/test/resources/testdata/gsim_2_levels/InstanceVariable_path.to.dataset$group.json
@@ -1,10 +1,7 @@
 {
   "id" : "path.to.dataset$group",
   "shortName" : "group",
-  "dataStructureComponentRole" : "ENTITY",
   "dataStructureComponentType" : "MEASURE",
-  "identifierComponentIsComposite" : false,
-  "identifierComponentIsUnique" : false,
   "representedVariable" : "/RepresentedVariable/RepresentedVariable_DUMMY",
   "sentinelValueDomain" : "/DescribedValueDomain/DescribedValueDomain_DUMMY",
   "name" : [ {

--- a/src/test/resources/testdata/gsim_2_levels/InstanceVariable_path.to.dataset$person.address.postcode.json
+++ b/src/test/resources/testdata/gsim_2_levels/InstanceVariable_path.to.dataset$person.address.postcode.json
@@ -1,10 +1,7 @@
 {
   "id" : "path.to.dataset$person.address.postcode",
   "shortName" : "postcode",
-  "dataStructureComponentRole" : "ENTITY",
   "dataStructureComponentType" : "MEASURE",
-  "identifierComponentIsComposite" : false,
-  "identifierComponentIsUnique" : false,
   "representedVariable" : "/RepresentedVariable/RepresentedVariable_DUMMY",
   "sentinelValueDomain" : "/DescribedValueDomain/DescribedValueDomain_DUMMY",
   "name" : [ {

--- a/src/test/resources/testdata/gsim_2_levels/InstanceVariable_path.to.dataset$person.address.street.json
+++ b/src/test/resources/testdata/gsim_2_levels/InstanceVariable_path.to.dataset$person.address.street.json
@@ -1,10 +1,7 @@
 {
   "id" : "path.to.dataset$person.address.street",
   "shortName" : "street",
-  "dataStructureComponentRole" : "ENTITY",
   "dataStructureComponentType" : "MEASURE",
-  "identifierComponentIsComposite" : false,
-  "identifierComponentIsUnique" : false,
   "representedVariable" : "/RepresentedVariable/RepresentedVariable_DUMMY",
   "sentinelValueDomain" : "/DescribedValueDomain/DescribedValueDomain_DUMMY",
   "name" : [ {

--- a/src/test/resources/testdata/gsim_2_levels/InstanceVariable_path.to.dataset$person.name.json
+++ b/src/test/resources/testdata/gsim_2_levels/InstanceVariable_path.to.dataset$person.name.json
@@ -1,10 +1,7 @@
 {
   "id" : "path.to.dataset$person.name",
   "shortName" : "name",
-  "dataStructureComponentRole" : "ENTITY",
   "dataStructureComponentType" : "MEASURE",
-  "identifierComponentIsComposite" : false,
-  "identifierComponentIsUnique" : false,
   "representedVariable" : "/RepresentedVariable/RepresentedVariable_DUMMY",
   "sentinelValueDomain" : "/DescribedValueDomain/DescribedValueDomain_DUMMY",
   "name" : [ {

--- a/src/test/resources/testdata/gsim_2_levels/InstanceVariable_path.to.dataset$person.sex.json
+++ b/src/test/resources/testdata/gsim_2_levels/InstanceVariable_path.to.dataset$person.sex.json
@@ -1,10 +1,7 @@
 {
   "id" : "path.to.dataset$person.sex",
   "shortName" : "sex",
-  "dataStructureComponentRole" : "ENTITY",
   "dataStructureComponentType" : "MEASURE",
-  "identifierComponentIsComposite" : false,
-  "identifierComponentIsUnique" : false,
   "representedVariable" : "/RepresentedVariable/RepresentedVariable_DUMMY",
   "sentinelValueDomain" : "/DescribedValueDomain/DescribedValueDomain_DUMMY",
   "name" : [ {

--- a/src/test/resources/testdata/template/gsim_result/InstanceVariable_path.to.dataset$gjeld.json
+++ b/src/test/resources/testdata/template/gsim_result/InstanceVariable_path.to.dataset$gjeld.json
@@ -1,10 +1,7 @@
 {
   "id" : "path.to.dataset$gjeld",
   "shortName" : "gjeld",
-  "dataStructureComponentRole" : "ENTITY",
   "dataStructureComponentType" : "MEASURE",
-  "identifierComponentIsComposite" : false,
-  "identifierComponentIsUnique" : false,
   "representedVariable" : "/RepresentedVariable/RepresentedVariable_DUMMY",
   "sentinelValueDomain" : "/DescribedValueDomain/ValueDomain_DUMMY",
   "name" : [ {

--- a/src/test/resources/testdata/template/gsim_result/InstanceVariable_path.to.dataset$innskudd.json
+++ b/src/test/resources/testdata/template/gsim_result/InstanceVariable_path.to.dataset$innskudd.json
@@ -1,10 +1,7 @@
 {
   "id" : "path.to.dataset$innskudd",
   "shortName" : "innskudd",
-  "dataStructureComponentRole" : "COUNT",
   "dataStructureComponentType" : "IDENTIFIER",
-  "identifierComponentIsComposite" : true,
-  "identifierComponentIsUnique" : true,
   "representedVariable" : "/RepresentedVariable/RepresentedVariable_DUMMY",
   "sentinelValueDomain" : "/DescribedValueDomain/ValueDomain_DUMMY",
   "name" : [ {

--- a/src/test/resources/testdata/template/gsim_result/InstanceVariable_path.to.dataset$kontonummer.json
+++ b/src/test/resources/testdata/template/gsim_result/InstanceVariable_path.to.dataset$kontonummer.json
@@ -1,10 +1,7 @@
 {
   "id" : "path.to.dataset$kontonummer",
   "shortName" : "kontonummer",
-  "dataStructureComponentRole" : "ENTITY",
   "dataStructureComponentType" : "MEASURE",
-  "identifierComponentIsComposite" : false,
-  "identifierComponentIsUnique" : false,
   "representedVariable" : "/RepresentedVariable/RepresentedVariable_DUMMY",
   "sentinelValueDomain" : "/DescribedValueDomain/ValueDomain_DUMMY",
   "name" : [ {


### PR DESCRIPTION
These object have been removed from [GSIM](https://github.com/statisticsnorway/gsim-raml-schema/pull/31 ) 
@kimcs I tested posting some of the example to [LDS](https://github.com/statisticsnorway/dapla-exploration-metadata-ingest/blob/feature/remove-obsolete-gsim-object/src/test/resources/testdata/gsim_1_level/InstanceVariable_path.to.dataset%24gjeld.json)  and it had a problem with this formating of the date: `2020-01-01T00:00Z` If want the seconds as well `2020-01-01T00:00:00Z` I am guessing this could be an issue if a date created mange to hit exactly on the minute? 